### PR TITLE
Fix some compiler warnings

### DIFF
--- a/fcl.h
+++ b/fcl.h
@@ -54,7 +54,7 @@ namespace fbh::fcl {
             void write_item(unsigned id, const t_item& item)
         {
             write_raw(id);
-            write_raw(pfc::downcast_guarded<uint32_t>(sizeof(t_item)));
+            write_raw(gsl::narrow<uint32_t>(sizeof(t_item)));
             write_raw(item);
         }
 

--- a/stdafx.h
+++ b/stdafx.h
@@ -6,6 +6,8 @@
 
 #include <ppl.h>
 
+#include <gsl/gsl>
+
 // Included before windows.h, because pfc.h includes winsock2.h
 #include "../pfc/pfc.h"
 

--- a/stream.h
+++ b/stream.h
@@ -104,7 +104,7 @@ namespace fbh {
         
         void skip_object(t_filesize bytes, abort_callback & p_abort) override
         {
-            seek_ex(file::seek_from_current, bytes, p_abort);
+            seek_ex(file::seek_from_current, gsl::narrow<t_ssize>(bytes), p_abort);
         }
 
         t_filesize skip(t_filesize bytes, abort_callback & p_abort) override


### PR DESCRIPTION
Particularly around mixed signed and unsigned comparisons. This also introduces a dependency on Microsoft GSL for its safe narrowing cast function.