### PR TITLE
Make fbh::print_to_console() compatible with Clang

### DIFF
--- a/console.h
+++ b/console.h
@@ -6,7 +6,7 @@ template <typename... Args>
 void print_to_console(Args&&... args)
 {
     console::formatter formatter;
-    (formatter << ... << args);
+    (formatter.add_string(std::forward<Args>(args)), ...);
 }
 
 } // namespace fbh


### PR DESCRIPTION
`fbh::print_to_console()` was generating the following error with Clang:

```
Error : call to function 'operator<<' that is neither visible in the template definition nor found by argument-dependent lookup
```

This changes the implementation to something that Clang is happier with.