### PR TITLE
Restore ability to pass non-string types to print_to_console()

### DIFF
--- a/console.h
+++ b/console.h
@@ -6,7 +6,8 @@ template <typename... Args>
 void print_to_console(Args&&... args)
 {
     console::formatter formatter;
-    (formatter.add_string(std::forward<Args>(args)), ...);
+    auto add_value = [&formatter](auto&& value) { formatter << value; };
+    (add_value(std::forward<Args>(args)), ...);
 }
 
 } // namespace fbh


### PR DESCRIPTION
#17 accidentally removed the ability to pass non-string types to print_to_console().

This restores that ability while maintaining compatibility with Clang.