### PR TITLE
Improve configuration helpers

### DIFF
--- a/stdafx.h
+++ b/stdafx.h
@@ -3,6 +3,7 @@
 #define OEMRESOURCE
 
 #include <atomic>
+#include <concepts>
 
 #include <ppl.h>
 


### PR DESCRIPTION
This:

- removes some deprecated helpers
- makes ConfigItem also provide the previous value in on change callbacks for arithmetic types
- migrates some FCL helpers to use concepts