### PR TITLE
Improve FCL reader

### DIFF
--- a/fbh.vcxproj
+++ b/fbh.vcxproj
@@ -89,7 +89,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -104,7 +104,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -118,7 +118,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_WIN32_WINNT=0x5000;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;NDEBUG;_LIB;_WIN32_WINNT=0x5000;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
@@ -133,7 +133,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_WIN32_WINNT=0x5000;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;NDEBUG;_LIB;_WIN32_WINNT=0x5000;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>

--- a/fcl.cpp
+++ b/fcl.cpp
@@ -38,8 +38,7 @@ void Reader::read_item(pfc::string8& p_out, t_size size)
     temp.fill(0);
 
     if (size) {
-        unsigned read = 0;
-        read = m_input->read(temp.get_ptr(), size, m_abort);
+        const auto read = m_input->read(temp.get_ptr(), size, m_abort);
         if (read != size)
             throw exception_io_data_truncation();
     }

--- a/fcl.h
+++ b/fcl.h
@@ -107,9 +107,23 @@ private:
 class Reader {
 public:
     /**
+     * \brief Reads an item.
+     *
+     * \tparam t_item    Item type
+     * \return           Read item
+     */
+    template <typename t_item>
+    t_item read_item()
+    {
+        t_item item{};
+        read_item<t_item>(item);
+        return item;
+    }
+
+    /**
      * \brief Reads an integer or float.
      *
-     * \tparam t_item    Intergral or floating-point type.
+     * \tparam t_item    Integral or floating-point type.
      * \param p_out        Object that receives the read value.
      */
     template <typename t_item, std::enable_if_t<std::is_arithmetic_v<t_item>>* = nullptr>


### PR DESCRIPTION
This makes some minor improvements to the FCL reader.

It also defines NOMINMAX (to disable the `min()` and `max()` macros).