### PR TITLE
Treat warnings as errors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions Condition="'$(PlatformToolset)'=='ClangCL'">%(AdditionalOptions) -Wno-error=delete-non-abstract-non-virtual-dtor</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/fbh.vcxproj
+++ b/fbh.vcxproj
@@ -112,6 +112,7 @@
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -128,6 +129,7 @@
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -142,6 +144,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -157,6 +160,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>

--- a/low_level_hook.cpp
+++ b/low_level_hook.cpp
@@ -13,7 +13,7 @@ private:
     MSLLHOOKSTRUCT m_mllhs;
 };
 
-class LowLevelMouseHookManager::HookThread : public pfc::thread {
+class LowLevelMouseHookManager::HookThread final : public pfc::thread {
 public:
     HookThread();
     ~HookThread();

--- a/sort.h
+++ b/sort.h
@@ -25,7 +25,6 @@ void sort_metadb_handle_list_by_format_get_permutation(TList&& tracks, mmh::Perm
 
                 metadb_handle_v2::ptr track;
                 track &= tracks[index];
-                const playable_location& location = track->get_location();
 
                 std::string title;
                 mmh::StringAdaptor interop_title(title);

--- a/stdafx.h
+++ b/stdafx.h
@@ -16,8 +16,14 @@
 #include <windows.h>
 #include <SHLWAPI.H>
 
-#include "../foobar2000/SDK/foobar2000.h"
+#include "../foobar2000/SDK/foobar2000-lite.h"
+#include "../foobar2000/SDK/cfg_var.h"
+#include "../foobar2000/SDK/config_object.h"
 #include "../foobar2000/SDK/coreDarkMode.h"
+#include "../foobar2000/SDK/initquit.h"
+#include "../foobar2000/SDK/library_callbacks.h"
+#include "../foobar2000/SDK/main_thread_callback.h"
+#include "../foobar2000/SDK/modeless_dialog.h"
 
 #include "../mmh/stdafx.h"
 #include "../ui_helpers/stdafx.h"


### PR DESCRIPTION
This updates the compiler options to treat warnings as errors, and fixes a few warnings from Clang.