### PR TITLE
Add helper function to enable WIL logging to foobar2000 console

### DIFF
--- a/fbh.vcxproj
+++ b/fbh.vcxproj
@@ -113,6 +113,7 @@
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -130,6 +131,7 @@
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -145,6 +147,7 @@
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -161,6 +164,7 @@
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -177,6 +181,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="wil.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="config_object.h" />
@@ -193,6 +198,7 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="stream.h" />
     <ClInclude Include="utility.h" />
+    <ClInclude Include="wil.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\mmh\mmh.vcxproj">

--- a/fbh.vcxproj.filters
+++ b/fbh.vcxproj.filters
@@ -8,6 +8,7 @@
     <ClCompile Include="low_level_hook.cpp" />
     <ClCompile Include="info_box.cpp" />
     <ClCompile Include="dark_mode.cpp" />
+    <ClCompile Include="wil.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="initquit.h" />
@@ -24,6 +25,7 @@
     <ClInclude Include="console.h" />
     <ClInclude Include="dark_mode.h" />
     <ClInclude Include="utility.h" />
+    <ClInclude Include="wil.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />

--- a/stdafx.h
+++ b/stdafx.h
@@ -16,6 +16,8 @@
 #include <windows.h>
 #include <SHLWAPI.H>
 
+#include <wil/result.h>
+
 #include "../foobar2000/SDK/foobar2000-lite.h"
 #include "../foobar2000/SDK/cfg_var.h"
 #include "../foobar2000/SDK/config_object.h"
@@ -41,3 +43,4 @@
 #include "sort.h"
 #include "stream.h"
 #include "utility.h"
+#include "wil.h"

--- a/wil.cpp
+++ b/wil.cpp
@@ -1,0 +1,28 @@
+#include "stdafx.h"
+
+using namespace mmh::literals::pcc;
+
+namespace fbh {
+
+void enable_wil_console_logging()
+{
+    static bool is_logging_configured{};
+
+    if (!is_logging_configured) {
+        wil::SetResultLoggingCallback([](const wil::FailureInfo& failure) noexcept {
+            std::array<wchar_t, 2048> log_message{};
+
+            if (FAILED(wil::GetFailureLogString(log_message.data(), log_message.size(), failure)))
+                return;
+
+            if (core_api::are_services_available())
+                console::print(log_message.data());
+            else
+                OutputDebugString(log_message.data());
+        });
+
+        is_logging_configured = true;
+    }
+}
+
+} // namespace fbh

--- a/wil.h
+++ b/wil.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace fbh {
+
+void enable_wil_console_logging();
+
+}


### PR DESCRIPTION
This adds a helper function that logs WIL-reported errors to the foobar2000 console for more visibility.