### PR TITLE
Mark Win32 and foobar2000 callback functions as noexcept

### DIFF
--- a/initquit.cpp
+++ b/initquit.cpp
@@ -3,12 +3,12 @@
 namespace fbh {
 initquit_factory_t<InitQuitManager> g_initquit_multiplexer;
 
-void InitQuitManager::on_init()
+void InitQuitManager::on_init() noexcept
 {
     for (t_size i = 0, count = m_instances.get_count(); i < count; i++)
         m_instances[i]->on_init();
 }
-void InitQuitManager::on_quit()
+void InitQuitManager::on_quit() noexcept
 {
     for (t_size i = 0, count = m_instances.get_count(); i < count; i++)
         m_instances[i]->on_quit();

--- a/initquit.h
+++ b/initquit.h
@@ -15,8 +15,8 @@ public:
     static void s_deregister_instance(InitQuitDynamic* ptr);
 
 private:
-    void on_init() override;
-    void on_quit() override;
+    void on_init() noexcept override;
+    void on_quit() noexcept override;
 
     pfc::ptr_list_t<InitQuitDynamic> m_instances;
 };

--- a/library.cpp
+++ b/library.cpp
@@ -1,60 +1,60 @@
 #include "stdafx.h"
 
 namespace fbh {
-class library_callback_multiplex_t : public library_callback {
+class LibraryCallbackManager : public library_callback {
 public:
     void register_callback(LibraryCallback* p_callback);
     void deregister_callback(LibraryCallback* p_callback);
 
 private:
-    void on_items_added(const pfc::list_base_const_t<metadb_handle_ptr>& p_data) override;
-    void on_items_removed(const pfc::list_base_const_t<metadb_handle_ptr>& p_data) override;
-    void on_items_modified(const pfc::list_base_const_t<metadb_handle_ptr>& p_data) override;
+    void on_items_added(const pfc::list_base_const_t<metadb_handle_ptr>& p_data) noexcept override;
+    void on_items_removed(const pfc::list_base_const_t<metadb_handle_ptr>& p_data) noexcept override;
+    void on_items_modified(const pfc::list_base_const_t<metadb_handle_ptr>& p_data) noexcept override;
 
     pfc::ptr_list_t<LibraryCallback> m_callbacks;
 };
 
-void library_callback_multiplex_t::register_callback(LibraryCallback* p_callback)
+void LibraryCallbackManager::register_callback(LibraryCallback* p_callback)
 {
     m_callbacks.add_item(p_callback);
 }
 
-void library_callback_multiplex_t::deregister_callback(LibraryCallback* p_callback)
+void LibraryCallbackManager::deregister_callback(LibraryCallback* p_callback)
 {
     m_callbacks.remove_item(p_callback);
 }
 
-void library_callback_multiplex_t::on_items_added(const pfc::list_base_const_t<metadb_handle_ptr>& p_data)
+void LibraryCallbackManager::on_items_added(const pfc::list_base_const_t<metadb_handle_ptr>& p_data) noexcept
 {
     t_size i, count = m_callbacks.get_count();
     for (i = 0; i < count; i++)
         m_callbacks[i]->on_items_added(p_data);
 }
 
-void library_callback_multiplex_t::on_items_removed(const pfc::list_base_const_t<metadb_handle_ptr>& p_data)
+void LibraryCallbackManager::on_items_removed(const pfc::list_base_const_t<metadb_handle_ptr>& p_data) noexcept
 {
     t_size i, count = m_callbacks.get_count();
     for (i = 0; i < count; i++)
         m_callbacks[i]->on_items_removed(p_data);
 }
 
-void library_callback_multiplex_t::on_items_modified(const pfc::list_base_const_t<metadb_handle_ptr>& p_data)
+void LibraryCallbackManager::on_items_modified(const pfc::list_base_const_t<metadb_handle_ptr>& p_data) noexcept
 {
     t_size i, count = m_callbacks.get_count();
     for (i = 0; i < count; i++)
         m_callbacks[i]->on_items_modified(p_data);
 }
 
-library_callback_factory_t<library_callback_multiplex_t> g_library_callback_multiplex;
+library_callback_factory_t<LibraryCallbackManager> g_library_callback_manager;
 
 namespace library_callback_manager {
 void register_callback(LibraryCallback* p_callback)
 {
-    g_library_callback_multiplex.get_static_instance().register_callback(p_callback);
+    g_library_callback_manager.get_static_instance().register_callback(p_callback);
 }
 void deregister_callback(LibraryCallback* p_callback)
 {
-    g_library_callback_multiplex.get_static_instance().deregister_callback(p_callback);
+    g_library_callback_manager.get_static_instance().deregister_callback(p_callback);
 }
 }; // namespace library_callback_manager
 

--- a/low_level_hook.cpp
+++ b/low_level_hook.cpp
@@ -20,7 +20,7 @@ public:
 
 private:
     static constexpr unsigned MSG_QUIT = WM_USER + 3;
-    static LRESULT CALLBACK s_on_event(int code, WPARAM wp, LPARAM lp);
+    static LRESULT CALLBACK s_on_event(int code, WPARAM wp, LPARAM lp) noexcept;
 
     void threadProc() override;
     HHOOK m_hook;
@@ -39,7 +39,7 @@ LowLevelMouseHookManager::HookThread::~HookThread()
     waitTillDone();
 }
 
-LRESULT LowLevelMouseHookManager::HookThread::s_on_event(int code, WPARAM wp, LPARAM lp)
+LRESULT LowLevelMouseHookManager::HookThread::s_on_event(int code, WPARAM wp, LPARAM lp) noexcept
 {
     if (code >= 0) {
         MainThreadCallback::ptr callback


### PR DESCRIPTION
This marks a some Win32 and foobar2000 callback functions as noexcept.

This is as it isn't allowed to throw C++ exceptions. `noexcept` will result in `std::terminate` being called if that happens.
