### PR TITLE
Only log explicitly logged WIL failures in release builds

### DIFF
--- a/wil.cpp
+++ b/wil.cpp
@@ -8,21 +8,27 @@ void enable_wil_console_logging()
 {
     static bool is_logging_configured{};
 
-    if (!is_logging_configured) {
-        wil::SetResultLoggingCallback([](const wil::FailureInfo& failure) noexcept {
-            std::array<wchar_t, 2048> log_message{};
+    if (is_logging_configured)
+        return;
 
-            if (FAILED(wil::GetFailureLogString(log_message.data(), log_message.size(), failure)))
-                return;
+    wil::SetResultLoggingCallback([](const wil::FailureInfo& failure) noexcept {
+        std::array<wchar_t, 2048> log_message{};
 
-            if (core_api::are_services_available())
-                console::print(log_message.data());
-            else
-                OutputDebugString(log_message.data());
-        });
+#ifdef NDEBUG
+        if (failure.type != wil::FailureType::Log)
+            return;
+#endif
 
-        is_logging_configured = true;
-    }
+        if (FAILED(wil::GetFailureLogString(log_message.data(), log_message.size(), failure)))
+            return;
+
+        if (core_api::are_services_available())
+            console::print(log_message.data());
+        else
+            OutputDebugString(log_message.data());
+    });
+
+    is_logging_configured = true;
 }
 
 } // namespace fbh


### PR DESCRIPTION
The WIL failure handler was logging failures when throwing an exception or returning a failure result, as well as when the failure was being explicitly logged.

This caused the same failure to be logged multiple times.

This changes the logic so that failures are only logged in release builds if they were being explicitly logged.