### PR TITLE
Check services are available in LowLevelMouseHookManager event handler

### DIFF
--- a/low_level_hook.h
+++ b/low_level_hook.h
@@ -21,7 +21,7 @@ private:
     LowLevelMouseHookManager(const LowLevelMouseHookManager&) = delete;
     LowLevelMouseHookManager(LowLevelMouseHookManager&&) = delete;
 
-    void on_event(WPARAM msg, const MSLLHOOKSTRUCT& mllhs);
+    void on_event(WPARAM msg, const MSLLHOOKSTRUCT& mllhs) const;
 
     std::unique_ptr<HookThread> m_hook_thread;
     std::vector<HookCallback*> m_callbacks;


### PR DESCRIPTION
There was an odd bug-check crash in `LowLevelMouseHookManager::HookThread::s_on_event()` when foobar2000 was shutting down. Unfortunately the crash was from a foobar2000 preview version for which symbols are no longer available. Best guess, however, is it the hook was somehow called after services had shut down. This therefore adds a check that services are available before queuing a main thread callback.