### PR TITLE
Reorder core dark mode dialog hooking operations

### DIFF
--- a/dark_mode.cpp
+++ b/dark_mode.cpp
@@ -17,17 +17,18 @@ fb2k::coreDarkModeObj::ptr create_dark_mode_obj()
 INT_PTR auto_dark_modal_dialog_box(
     UINT resource_id, HWND parent_window, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
 {
-    const auto dark_mode_obj = create_dark_mode_obj();
+    auto dark_mode_obj = create_dark_mode_obj();
 
     return uih::modal_dialog_box(resource_id, parent_window,
         [dark_mode_obj{std::move(dark_mode_obj)}, on_message{std::move(on_message)}](
             HWND wnd, UINT msg, WPARAM wp, LPARAM lp) {
+            if (dark_mode_obj.is_valid() && msg == WM_INITDIALOG)
+                dark_mode_obj->addDialog(wnd);
+
             const auto result = on_message(wnd, msg, wp, lp);
 
-            if (dark_mode_obj.is_valid() && msg == WM_INITDIALOG) {
-                dark_mode_obj->addDialog(wnd);
+            if (dark_mode_obj.is_valid() && msg == WM_INITDIALOG)
                 dark_mode_obj->addControls(wnd);
-            }
 
             return result;
         });
@@ -36,18 +37,19 @@ INT_PTR auto_dark_modal_dialog_box(
 std::tuple<HWND, bool> auto_dark_modeless_dialog_box(
     UINT resource_id, HWND parent_window, std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
 {
-    const auto dark_mode_obj = create_dark_mode_obj();
+    auto dark_mode_obj = create_dark_mode_obj();
     bool has_dark_mode = dark_mode_obj.is_valid();
 
     const auto wnd = uih::modeless_dialog_box(resource_id, parent_window,
         [dark_mode_obj{std::move(dark_mode_obj)}, on_message{std::move(on_message)}](
             HWND wnd, UINT msg, WPARAM wp, LPARAM lp) {
+            if (dark_mode_obj.is_valid() && msg == WM_INITDIALOG)
+                dark_mode_obj->addDialog(wnd);
+
             const auto result = on_message(wnd, msg, wp, lp);
 
-            if (dark_mode_obj.is_valid() && msg == WM_INITDIALOG) {
-                dark_mode_obj->addDialog(wnd);
+            if (dark_mode_obj.is_valid() && msg == WM_INITDIALOG)
                 dark_mode_obj->addControls(wnd);
-            }
 
             return result;
         });


### PR DESCRIPTION
This amends the core dark mode dialog helpers to call `coreDarkModeObj::addDialog()` earlier, so that if the dialog subclasses the window, its subclass procedure is called before the `coreDarkModeObj` one.